### PR TITLE
chore: add CI check to enforce required files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check required files
+        run: |
+          for f in README.md LICENSE .github/workflows/ci.yml; do
+            if [ ! -f "$f" ]; then
+              echo "Missing required file: $f"
+              exit 1
+            fi
+          done
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Adds a CI step to fail builds if README.md, LICENSE, or ci.yml are missing.