### PR TITLE
Fix slug references in bootstrap scripts

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -10,12 +10,12 @@ fi
 REPO_INFO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "unknown/repo")
 echo "📦 Repo: $REPO_INFO"
 
-EXPECTED_REPO="pazztech/project-bootstrap"
+EXPECTED_REPO="${EXPECTED_REPO:-$REPO_INFO}"
 if [[ "$REPO_INFO" != "$EXPECTED_REPO" ]]; then
-  echo "⚠️  WARNING: You are running bootstrap on '$REPO_INFO', expected '$EXPECTED_REPO'"
+  echo "⚠️  WARNING: You are running bootstrap on '$REPO_INFO', expected '$EXPECTED_REPO'" >&2
   read -p "Proceed anyway? [y/N] " -r
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "❌ Aborted by user."
+    echo "❌ Aborted by user." >&2
     exit 1
   fi
 fi

--- a/bin/post-fork.sh
+++ b/bin/post-fork.sh
@@ -16,14 +16,21 @@ fi
 
 REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
 echo "📁 Repo detected: $REPO_NAME"
-sed -i '' "s|<org>/<repo>|npazzaglia/${REPO_NAME}|g" README.md || echo "⚠️ Failed to update README.md"
+if command -v gh &> /dev/null; then
+  SLUG=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+else
+  SLUG=$(git remote get-url origin | sed -E 's@.*github.com[/:]([^/]+/[^.]+)(\.git)?@\1@')
+fi
+sed -i.bak "s|<org>/<repo>|$SLUG|g" README.md && rm README.md.bak || echo "⚠️ Failed to update README.md"
 
 echo "✅ Updated README repo slugs"
 
 echo "🔐 Configuring GitHub Secrets..."
 echo "🔐 Setting up secrets (requires gh auth)"
-gh secret set docker_username --body "REPLACE_ME"
-gh secret set docker_token --body "REPLACE_ME"
+: "${DOCKER_USERNAME:?Set DOCKER_USERNAME environment variable}"
+: "${DOCKER_TOKEN:?Set DOCKER_TOKEN environment variable}"
+gh secret set docker_username --body "$DOCKER_USERNAME"
+gh secret set docker_token --body "$DOCKER_TOKEN"
 
 echo "📌 Enabling GitHub features"
 gh repo edit --enable-issues=true --enable-projects=true --enable-discussions=true
@@ -37,3 +44,4 @@ else
 fi
 
 echo "Post-fork complete"
+

--- a/bin/sync-template.sh
+++ b/bin/sync-template.sh
@@ -37,7 +37,16 @@ if ! command -v gh &> /dev/null; then
   exit 1
 fi
 
-TEMPLATE_REPO="npazzaglia/repo-template"
+if command -v gh &> /dev/null; then
+  DEFAULT_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+else
+  DEFAULT_REPO=""
+fi
+TEMPLATE_REPO="${TEMPLATE_REPO:-$DEFAULT_REPO}"
+if [[ -z "$TEMPLATE_REPO" ]]; then
+  log "TEMPLATE_REPO not specified and could not be determined."
+  exit 1
+fi
 TEMPLATE_REMOTE="upstream"
 LOCAL_TMP_DIR="./.tmp-template-sync"
 
@@ -46,7 +55,8 @@ cd "$LOCAL_TMP_DIR"
 
 log "Starting template sync..."
 
-forks=$(gh repo list npazzaglia --fork --json nameWithOwner -q '.[].nameWithOwner')
+TEMPLATE_OWNER="${TEMPLATE_REPO%%/*}"
+forks=$(gh repo list "$TEMPLATE_OWNER" --fork --json nameWithOwner -q '.[].nameWithOwner')
 
 for fork in $forks; do
   log "Processing $fork"


### PR DESCRIPTION
## Summary
- make bootstrap slug check configurable
- detect repo slug dynamically in post-fork script
- use env vars instead of REPLACE_ME placeholders for secrets
- allow sync-template slug via env var and auto-detection

## Testing
- `shellcheck` on all shell scripts
- `./scripts/test-smoke.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888fb8a9464832ead579f9120379856