### PR TITLE
Fix leftover repo-template references

### DIFF
--- a/.template.json
+++ b/.template.json
@@ -1,5 +1,5 @@
 {
-  "template_name": "repo-template",
+  "template_name": "project-bootstrap",
   "description": "Reusable GitHub project template for devops, infra, and platform repos.",
   "version": "v1.0.0",
   "author": "Nick Pazzaglia",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: "If you use this project, please cite it as below."
 authors:
   - family-names: Pazzaglia
     given-names: Nick
-title: "repo-template"
+title: "project-bootstrap"
 version: "0.1.0-alpha"
 date-released: 2025-06-19
 type: software
-repository-code: "https://github.com/npazzaglia/repo-template"
+repository-code: "https://github.com/npazzaglia/project-bootstrap"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing to repo-template
+# Contributing to project-bootstrap
 
 Thank you for your interest in contributing to this project! We welcome contributions in various forms, including code, documentation, bug reports, and feature suggestions. This document outlines the process for contributing to ensure a smooth collaboration.
 
 ## How to Contribute
 
 ### Reporting Issues
-- **Before reporting an issue**, please search the [issue tracker](https://github.com/npazzaglia/repo-template/issues) to see if the problem has already been reported.
+- **Before reporting an issue**, please search the [issue tracker](https://github.com/npazzaglia/project-bootstrap/issues) to see if the problem has already been reported.
 - Provide a clear and descriptive title.
 - Include a detailed description of the issue, including steps to reproduce it, expected behavior, and screenshots or logs if applicable.
 
@@ -60,4 +60,4 @@ By contributing, you agree that your contributions will be licensed under the sa
 ## Acknowledgements
 We appreciate your time and effort in helping to improve this project. Your contributions make a significant impact!
 
-Thank you for contributing to repo-template!
+Thank you for contributing to project-bootstrap!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# repo-template
+# project-bootstrap
 
 > 🛠️ A modern, opinionated GitHub template for scaffolding clean, documented, and CI-ready software projects.
 


### PR DESCRIPTION
## Summary
- replace mentions of `repo-template` with `project-bootstrap`

## Testing
- `./scripts/test-smoke.sh`

------
https://chatgpt.com/codex/tasks/task_e_68890316b154832e968d818162c90ab0