### PR TITLE
Fix help target formatting in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: help bootstrap sync lint test
 
 help:
-@echo "Available targets:"
-@echo "  bootstrap - Run project bootstrap script"
-@echo "  sync      - Run template sync script"
-@echo "  lint      - Run shellcheck on all .sh files"
-@echo "  test      - Run test suite"
+	@echo "Available targets:"
+	@echo "  bootstrap - Run project bootstrap script"
+	@echo "  sync      - Run template sync script"
+	@echo "  lint      - Run shellcheck on all .sh files"
+	@echo "  test      - Run test suite"
 
 bootstrap:
 	./bin/bootstrap.sh


### PR DESCRIPTION
## Summary
- add required tab indentation for `help` target commands
- verify `make test` runs `./scripts/test-smoke.sh`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688908b16fac832ebce0850a35c0d2b9